### PR TITLE
Fix for loading of CCBMFontConfiguration - i.e. .FNT files.

### DIFF
--- a/cocos2d/cocos2d.iOS.csproj
+++ b/cocos2d/cocos2d.iOS.csproj
@@ -432,6 +432,11 @@
     <Compile Include="Platform\CCIFocusable.cs" />
     <Compile Include="predefine\CCTypes.cs" />
     <Compile Include="support\CCUtils.cs" />
+    <Compile Include="Platform\ContentReaders\CCBMFontPaddingReader.cs" />
+    <Compile Include="Platform\ContentReaders\CCPointReader.cs" />
+    <Compile Include="Platform\ContentReaders\CCRectReader.cs" />
+    <Compile Include="Platform\ContentReaders\CCSizeReader.cs" />
+    <Compile Include="Platform\ContentReaders\KerningHashElementReader.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\MonoGame\ThirdParty\Lidgren.Network\Lidgren.Network.iOS.csproj">
@@ -442,5 +447,8 @@
       <Project>{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}</Project>
       <Name>MonoGame.Framework.iOS</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Platform\ContentReaders\" />
   </ItemGroup>
 </Project>

--- a/cocos2d/platform/ContentReaders/CCBMFontPaddingReader.cs
+++ b/cocos2d/platform/ContentReaders/CCBMFontPaddingReader.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Xna.Framework.Content;
+
+namespace cocos2d
+{
+    internal class CCBMFontPaddingtReader : ContentTypeReader<CCBMFontConfiguration.ccBMFontPadding>
+    {
+        public CCBMFontPaddingtReader()
+        {
+        }
+        
+        protected override CCBMFontConfiguration.ccBMFontPadding Read (ContentReader input, CCBMFontConfiguration.ccBMFontPadding existingInstance)
+        {
+            var bottom = input.ReadInt32 ();
+            var left = input.ReadInt32 ();
+            var right = input.ReadInt32 ();
+            var top = input.ReadInt32 ();
+
+            var objectSize = new CCBMFontConfiguration.ccBMFontPadding();
+            objectSize.bottom = bottom;
+            objectSize.left = left;
+            objectSize.right = right;
+            objectSize.top = top;
+
+            return objectSize;
+        }
+        
+    }
+}

--- a/cocos2d/platform/ContentReaders/CCPointReader.cs
+++ b/cocos2d/platform/ContentReaders/CCPointReader.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.Xna.Framework.Content;
+
+namespace cocos2d
+{
+    public class CCPointReader : ContentTypeReader<CCPoint>
+    {
+        public CCPointReader()
+        {
+        }
+        
+        protected override CCPoint Read (ContentReader input, CCPoint existingInstance)
+        {
+            var x = input.ReadSingle ();
+            var y = input.ReadSingle ();
+
+            var objectPoint = new CCPoint(x, y);
+            
+            return objectPoint;
+        }
+        
+    }
+}
+

--- a/cocos2d/platform/ContentReaders/CCRectReader.cs
+++ b/cocos2d/platform/ContentReaders/CCRectReader.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.Xna.Framework.Content;
+
+namespace cocos2d
+{
+    public class CCRectReader : ContentTypeReader<CCRect>
+    {
+        public CCRectReader()
+        {
+        }
+
+        protected override CCRect Read (ContentReader input, CCRect existingInstance)
+        {
+            var x = input.ReadSingle ();
+            var y = input.ReadSingle ();
+            var width = input.ReadSingle ();
+            var height = input.ReadSingle ();
+
+            var objectRect = new CCRect(x, y, width, height);
+
+            return objectRect;
+        }
+
+    }
+}
+

--- a/cocos2d/platform/ContentReaders/CCSizeReader.cs
+++ b/cocos2d/platform/ContentReaders/CCSizeReader.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.Xna.Framework.Content;
+
+namespace cocos2d
+{
+    public class CCSizeReader : ContentTypeReader<CCSize>
+    {
+        public CCSizeReader()
+        {
+        }
+        
+        protected override CCSize Read (ContentReader input, CCSize existingInstance)
+        {
+            var width = input.ReadSingle ();
+            var height = input.ReadSingle ();
+            
+            var objectSize = new CCSize(width, height);
+            
+            return objectSize;
+        }
+        
+    }
+}
+

--- a/cocos2d/platform/ContentReaders/KerningHashElementReader.cs
+++ b/cocos2d/platform/ContentReaders/KerningHashElementReader.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.Xna.Framework.Content;
+
+namespace cocos2d
+{
+    public class KerningHashElementReader : ContentTypeReader<CCBMFontConfiguration.tKerningHashElement>
+    {
+        public KerningHashElementReader()
+        {
+        }
+        
+        protected override CCBMFontConfiguration.tKerningHashElement Read (ContentReader input, CCBMFontConfiguration.tKerningHashElement existingInstance)
+        {
+            var amount = input.ReadInt32 ();
+            var key = input.ReadInt32 ();
+            
+            var objectSize = new CCBMFontConfiguration.tKerningHashElement();
+            objectSize.amount = amount;
+            objectSize.key = key;
+            
+            return objectSize;
+        }
+        
+    }
+}
+

--- a/tests/tests/tests.iOS.csproj
+++ b/tests/tests/tests.iOS.csproj
@@ -55,12 +55,12 @@
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <MtouchDebug>True</MtouchDebug>
     <MtouchUseArmv7>false</MtouchUseArmv7>
-    <CodesignKey>iPhone Developer: jacob anderson (49YP447S66)</CodesignKey>
+    <CodesignKey>iPhone Developer: Kenneth James Pouncey (83ASFFXWXR)</CodesignKey>
     <IpaPackageName />
     <MtouchI18n />
     <MtouchArch>ARMv7</MtouchArch>
     <AssemblyName>cocos2dtests</AssemblyName>
-    <MtouchSdkVersion>6.1</MtouchSdkVersion>
+    <CrashReportingApiKey />
     <MtouchLink>None</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">


### PR DESCRIPTION
Have tested this on an iOS device and it works.  Granted it is probably a hack and not preferable but we can look at this as a stop gap for now.
