### PR TITLE
Fix to PlistDocument.cs ignoring every second key when reading a dict (from non-whitespaced plist files)

### DIFF
--- a/cocos2d/platform/PList/PlistDocument.cs
+++ b/cocos2d/platform/PList/PlistDocument.cs
@@ -195,7 +195,7 @@ namespace cocos2d
                 // when there is no whitespace between nodes, we might already be at
                 // the next key element, so reading to next sibling would jump over
                 // the next (current) key element
-                if (!reader.Name.Equals("key"))
+                if (!"key".Equals(reader.Name))
                     reader.ReadToNextSibling("key");                
             }
             return dict;


### PR DESCRIPTION
Bugfix: Reading a dict in a plist document only handles every second key in cases where there is no whitespace between nodes.
