### PR TITLE
Box2d - Misc initializations - Initialize BroadPhase Dynamic Tree

### DIFF
--- a/box2d/Collision/b2BroadPhase.cs
+++ b/box2d/Collision/b2BroadPhase.cs
@@ -43,6 +43,7 @@ namespace Box2D.Collision
             m_moveCapacity = 16;
             m_moveCount = 0;
             m_moveBuffer = new int[m_moveCapacity];
+			m_tree = new b2DynamicTree();
         }
 
         public int CreateProxy(b2AABB aabb, object userData)

--- a/box2d/Collision/b2DynamicTree.cs
+++ b/box2d/Collision/b2DynamicTree.cs
@@ -77,9 +77,15 @@ namespace Box2D.Collision
             // Build a linked list for the free list.
             for (int i = 0; i < m_nodeCapacity - 1; ++i)
             {
+				if (m_nodes[i] == null)
+					m_nodes[i] = new b2TreeNode();
+
                 m_nodes[i].next = i + 1;
                 m_nodes[i].height = -1;
             }
+			if (m_nodes[m_nodeCapacity - 1] == null)
+				m_nodes[m_nodeCapacity - 1] = new b2TreeNode();
+
             m_nodes[m_nodeCapacity - 1].next = b2TreeNode.b2_nullNode;
             m_nodes[m_nodeCapacity - 1].height = -1;
             m_freeList = 0;


### PR DESCRIPTION
Dynamic Tree was not initializedd each b2TreeNode entry in the Link List of b2TreeNodes need to be initialized as well.
