### PR TITLE
b2DynaimicTree - Use array copy instead of for loop to copy old nodes.

### DIFF
--- a/box2d/Collision/b2Collision.cs
+++ b/box2d/Collision/b2Collision.cs
@@ -11,10 +11,10 @@ namespace Box2D.Collision
     /// This is used for determining the state of contact points.
     public enum b2PointState
     {
-        b2_nullState,        ///< point does not exist
-        b2_addState,        ///< point was added in the update
-        b2_persistState,    ///< point persisted across the update
-        b2_removeState        ///< point was removed in the update
+        b2_nullState,        //< point does not exist
+        b2_addState,        //< point was added in the update
+        b2_persistState,    //< point persisted across the update
+        b2_removeState        //< point was removed in the update
     }
 
     /// Used for computing contact manifolds.

--- a/box2d/Collision/b2DynamicTree.cs
+++ b/box2d/Collision/b2DynamicTree.cs
@@ -118,10 +118,7 @@ namespace Box2D.Collision
                 m_nodes = new b2TreeNode[m_nodeCapacity];
 
 				// initialize new b2TreeNode
-				for (int i = 0; i < m_nodeCount; i++)
-				{
-					m_nodes[i] = oldNodes[i];
-				}
+                oldNodes.CopyTo(m_nodes, 0);
 
                 // Build a linked list for the free list. The parent
                 // pointer becomes the "next" pointer.


### PR DESCRIPTION
I used a for loop to copy when I first did the copy of the old nodes.  Array.CopyTo should be faster.
