### PR TITLE
Box2D Windows 8 Support fixed

### DIFF
--- a/cocos2d-xna.winrt.sln
+++ b/cocos2d-xna.winrt.sln
@@ -6,7 +6,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestWin8Store", "testWin8St
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.Windows8", "MonoGame\MonoGame.Framework\MonoGame.Framework.Windows8.csproj", "{0518563C-ACCA-4A14-8C5D-DDBE93E2605F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "box2d", "box2d\box2d.csproj", "{B81B6701-7A78-4846-BF6F-04E0591F0F38}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "box2d", "box2d\box2d.Windows8.csproj", "{B81B6701-7A78-4846-BF6F-04E0591F0F38}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
I have changed the windows 8 solution so that it loads the windows 8 box2d instead of the ordinary one, so that it will load in visual studio
