### PR TITLE
Fix for issue #325

### DIFF
--- a/cocos2d/denshion/CCMusicPlayer.cs
+++ b/cocos2d/denshion/CCMusicPlayer.cs
@@ -63,14 +63,22 @@ namespace CocosDenshion
 
         public void SaveMediaState()
         {
-            // User is playing a song, so remember the song state.
-            m_SongToPlayAfterClose = MediaPlayer.Queue.ActiveSong;
-            m_VolumeAfterClose = MediaPlayer.Volume;
+            try
+            {
+                // User is playing a song, so remember the song state.
+                m_SongToPlayAfterClose = MediaPlayer.Queue.ActiveSong;
+                m_VolumeAfterClose = MediaPlayer.Volume;
 #if !NETFX_CORE
-            m_PlayPositionAfterClose = MediaPlayer.PlayPosition;
+                m_PlayPositionAfterClose = MediaPlayer.PlayPosition;
 #endif
-            m_IsRepeatingAfterClose = MediaPlayer.IsRepeating;
-            m_IsShuffleAfterClose = MediaPlayer.IsShuffled;
+                m_IsRepeatingAfterClose = MediaPlayer.IsRepeating;
+                m_IsShuffleAfterClose = MediaPlayer.IsShuffled;
+            }
+            catch (Exception ex)
+            {
+                CCLog.Log("Failed to save the media state of the game.");
+                CCLog.Log(ex.ToString());
+            }
         }
 
         public void RestoreMediaState()
@@ -84,8 +92,10 @@ namespace CocosDenshion
                 MediaPlayer.Volume = m_VolumeAfterClose;
                 MediaPlayer.Play(m_SongToPlayAfterClose);
             }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    CCLog.Log("Failed to restore the media state of the game.");
+                    CCLog.Log(ex.ToString());
                 }
         }
         }

--- a/cocos2d/platform/CCApplication.cs
+++ b/cocos2d/platform/CCApplication.cs
@@ -58,6 +58,7 @@ namespace Cocos2D
 
             WindowSetup = pp;
             Content = game.Content;
+            HandleMediaStateAutomatically = true;
 
             if (m_graphicsService.GraphicsDevice != null)
             {
@@ -143,12 +144,17 @@ namespace Cocos2D
 
         }
 
+        protected bool HandleMediaStateAutomatically { get; set; }
+
         private void GameActivated(object sender, EventArgs e)
         {
             // Clear out the prior gamepad state because we don't want it anymore.
             m_PriorGamePadState.Clear();
 #if !IOS
-            CocosDenshion.CCSimpleAudioEngine.SharedEngine.SaveMediaState();
+            if (HandleMediaStateAutomatically)
+            {
+                CocosDenshion.CCSimpleAudioEngine.SharedEngine.SaveMediaState();
+            }
 #endif
             ApplicationWillEnterForeground();
         }
@@ -157,7 +163,10 @@ namespace Cocos2D
         {
             ApplicationDidEnterBackground();
 #if !IOS
-            CocosDenshion.CCSimpleAudioEngine.SharedEngine.RestoreMediaState();
+            if (HandleMediaStateAutomatically)
+            {
+                CocosDenshion.CCSimpleAudioEngine.SharedEngine.RestoreMediaState();
+            }
 #endif
         }
 

--- a/tests/tests/classes/AppDelegate.cs
+++ b/tests/tests/classes/AppDelegate.cs
@@ -13,6 +13,9 @@ namespace tests
             s_pSharedApplication = this;
             CCDrawManager.InitializeDisplay(game, graphics, DisplayOrientation.LandscapeRight | DisplayOrientation.LandscapeLeft);
 
+#if WINDOWS_PHONE8
+            HandleMediaStateAutomatically = false; // Bug in MonoGame - https://github.com/Cocos2DXNA/cocos2d-xna/issues/325
+#endif
             game.Window.AllowUserResizing = true;
             graphics.PreferMultiSampling = false;
 #if WINDOWS || WINDOWSGL || WINDOWSDX || MACOS


### PR DESCRIPTION
Added an overridable flag to handle the media state management of the game. this was tested with the WP8 emulator to work per the reproducing steps in the issue description.
