### PR TITLE
Fix for the build scripts to deploy the 1.1 version of the nuget packages

### DIFF
--- a/scripts/deploy-Android.build
+++ b/scripts/deploy-Android.build
@@ -59,14 +59,14 @@
       </exec> 
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.Android.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.Android.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>
       </exec>
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.Ouya.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.Ouya.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>

--- a/scripts/deploy-MG-Windows.build
+++ b/scripts/deploy-MG-Windows.build
@@ -59,14 +59,14 @@
       </exec> 
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsGL.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsGL.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>
       </exec>
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsDX.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsDX.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>

--- a/scripts/deploy-Microsoft.build
+++ b/scripts/deploy-Microsoft.build
@@ -60,14 +60,14 @@
       </exec> 
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.Windows.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.Windows.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>
       </exec>
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsPhone7.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsPhone7.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>

--- a/scripts/deploy-Windows8.build
+++ b/scripts/deploy-Windows8.build
@@ -59,14 +59,14 @@
       </exec> 
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.Windows8.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.Windows8.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>
       </exec>
       <exec program="${nuget.cmd.dir.path}">
         <arg value="push"/>
-	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsPhone8.0.9.0.0.nupkg"/>
+	<arg value="${packages.dir.path}\Cocos2D-XNA.WindowsPhone8.1.1.0.0.nupkg"/>
 	<arg value="-s"/>
 	<arg value="http://nuget.cocos2dxna.com/"/>
 	<arg value="${apikey}"/>


### PR DESCRIPTION
The nugget repository was only deploying version 0.9 and we are on 1.1. This should fix the discrepancy.
