### PR TITLE
fix the nuget packager for windows 8.

### DIFF
--- a/ProjectTemplates/NuGet/Cocos2D.Windows8.nuspec
+++ b/ProjectTemplates/NuGet/Cocos2D.Windows8.nuspec
@@ -31,7 +31,9 @@
   </metadata>
 
   <files>
-    <file src="..\..\cocos2d\bin\Windows8\Release\*.dll" target="lib\Windows8" />
+    <file src="..\..\cocos2d\bin\Windows8\Release\box2d.dll" target="lib\Windows8" />
+    <file src="..\..\cocos2d\bin\Windows8\Release\cocos2d-xna.dll" target="lib\Windows8" />
+    <file src="..\..\cocos2d\bin\Windows8\Release\ICSharpCode.SharpZipLib.dll" target="lib\Windows8" />
     <file src="..\..\MonoGame\MonoGame.Framework\bin\Windows8\Release\*.dll" target="lib\Windows8" />
   </files>
 


### PR DESCRIPTION
*.dll was causing a library packager error during the packaging step. this is verified fixed. 
