### PR TITLE
White points under font, on android

### DIFF
--- a/cocos2d/label_nodes/CCLabel-Android.cs
+++ b/cocos2d/label_nodes/CCLabel-Android.cs
@@ -108,7 +108,10 @@ namespace Cocos2D
 
             var size = GetMeasureString(text);
 
-            CreateBitmap((int) size.Width + 2, (int) size.Height + 2);
+            var w = (int)(Math.Ceiling(size.Width += 2));
+            var h = (int)(Math.Ceiling(size.Height += 2));
+
+            CreateBitmap(w, h);
 
             _canvas.DrawColor(Android.Graphics.Color.Black);
 


### PR DESCRIPTION
height is more 1px than other platforms.
cause font paint like this:
![fontbug](https://f.cloud.github.com/assets/1435991/1992391/ad23e182-84bb-11e3-9672-b757ee85d650.png)
