### PR TITLE
The chinese char's width compute error on WindowsGL

### DIFF
--- a/cocos2d/label_nodes/CCLabel-Gdi.cs
+++ b/cocos2d/label_nodes/CCLabel-Gdi.cs
@@ -43,7 +43,7 @@ namespace Cocos2D
         [DllImport("user32.dll")]
         static extern bool ReleaseDC(IntPtr hWnd, IntPtr hDC);
 
-        [DllImport("gdi32.dll")]
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto)]
         private static extern bool GetCharABCWidthsFloat(IntPtr hdc, uint iFirstChar, uint iLastChar, [Out] ABCFloat[] lpABCF);
 
         [DllImport("gdi32.dll", ExactSpelling = true, PreserveSig = true, SetLastError = true)]


### PR DESCRIPTION
The chinese char's width compute error on WindowsGL
CharSet = CharSet.Ansi is the default for C#, so change to  CharSet.Auto
