### PR TITLE
Fix GameStarterKit.Mac build error.

### DIFF
--- a/Samples/GameStarterKit/GameStarterKit.Mac.sln
+++ b/Samples/GameStarterKit/GameStarterKit.Mac.sln
@@ -7,9 +7,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "box2d.MacOS", "..\..\box2d\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cocos2d.MacOS", "..\..\cocos2d\cocos2d.MacOS.csproj", "{A83510D8-7AED-411E-9616-DCFEA180969E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.MacOS", "..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.MacOS.csproj", "{36C538E6-C32A-4A8D-A39C-566173D7118E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lidgren.Network.MacOS", "..\..\MonoGame\ThirdParty\Lidgren.Network\Lidgren.Network.MacOS.csproj", "{AE483C29-042E-4226-BA52-D247CE7676DA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lidgren.Network.MacOS", "..\..\..\MonoGame\ThirdParty\Lidgren.Network\Lidgren.Network.MacOS.csproj", "{AE483C29-042E-4226-BA52-D247CE7676DA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.MacOS", "..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.MacOS.csproj", "{36C538E6-C32A-4A8D-A39C-566173D7118E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Samples/GameStarterKit/GameStarterKit/GameStartKit/AppDelegate.cs
+++ b/Samples/GameStarterKit/GameStarterKit/GameStartKit/AppDelegate.cs
@@ -58,7 +58,7 @@ namespace GameStarterKit
 
 
 			// 2D projection
-			pDirector.Projection = ccDirectorProjection.kCCDirectorProjection2D;
+			pDirector.Projection = CCDirectorProjection.Projection2D;
 
 			// Enables High Res mode (Retina Display) on iPhone 4 and maintains low res on all other devices
 			//if( ! [director_ enableRetinaDisplay:YES] )
@@ -66,9 +66,9 @@ namespace GameStarterKit
 
 
 #if WINDOWS || MACOS || LINUX || OUYA || XBOX
-			var resPolicy = ResolutionPolicy.ExactFit;
+			var resPolicy = CCResolutionPolicy.ExactFit;
 #else
-			var resPolicy = ResolutionPolicy.ShowAll;
+			var resPolicy = CCResolutionPolicy.ShowAll;
 #endif
 
 			CCDrawManager.SetDesignResolutionSize(preferredWidth, 

--- a/Samples/GameStarterKit/GameStarterKit/GameStartKit/GameMenu.cs
+++ b/Samples/GameStarterKit/GameStarterKit/GameStartKit/GameMenu.cs
@@ -99,7 +99,7 @@ namespace GameStarterKit
 		#endregion
 
 		#region  POP (remove) SCENE and continue playing current level
-		public override void TouchesBegan (System.Collections.Generic.List<CCTouch> touches, CCEvent event_)
+		public override void TouchesBegan (System.Collections.Generic.List<CCTouch> touches)
 		{
 			CCDirector.SharedDirector.PopScene();
 		}

--- a/Samples/GameStarterKit/GameStarterKit/GameStarterKit.Mac.csproj
+++ b/Samples/GameStarterKit/GameStarterKit/GameStarterKit.Mac.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;MONOMAC</DefineConstants>
+    <DefineConstants>DEBUG;MONOMAC;MACOS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <IncludeMonoRuntime>false</IncludeMonoRuntime>
@@ -27,6 +27,9 @@
     <EnablePackageSigning>false</EnablePackageSigning>
     <CreatePackage>false</CreatePackage>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
+    <PackageSigningKey>Developer ID Installer</PackageSigningKey>
+    <I18n>
+    </I18n>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Optimize>true</Optimize>
@@ -97,11 +100,11 @@
       <Project>{A83510D8-7AED-411E-9616-DCFEA180969E}</Project>
       <Name>cocos2d.MacOS</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\MonoGame\ThirdParty\Lidgren.Network\Lidgren.Network.MacOS.csproj">
+    <ProjectReference Include="..\..\..\MonoGame\ThirdParty\Lidgren.Network\Lidgren.Network.MacOS.csproj">
       <Project>{AE483C29-042E-4226-BA52-D247CE7676DA}</Project>
       <Name>Lidgren.Network.MacOS</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.MacOS.csproj">
+    <ProjectReference Include="..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.MacOS.csproj">
       <Project>{36C538E6-C32A-4A8D-A39C-566173D7118E}</Project>
       <Name>MonoGame.Framework.MacOS</Name>
     </ProjectReference>

--- a/cocos2d/cocos2d.MacOS.csproj
+++ b/cocos2d/cocos2d.MacOS.csproj
@@ -12,7 +12,7 @@
     <RootNamespace>Cocos2D</RootNamespace>
     <SuppressXamMacUpsell>True</SuppressXamMacUpsell>
     <AssemblyName>cocos2d-xna</AssemblyName>
-	<UseMSBuildEngine>False</UseMSBuildEngine>
+    <UseMSBuildEngine>False</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -29,7 +29,6 @@
     <EnablePackageSigning>False</EnablePackageSigning>
     <IncludeMonoRuntime>False</IncludeMonoRuntime>
     <UseSGen>False</UseSGen>
-	<UseMSBuildEngine>False</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -45,7 +44,6 @@
     <EnablePackageSigning>False</EnablePackageSigning>
     <IncludeMonoRuntime>False</IncludeMonoRuntime>
     <UseSGen>False</UseSGen>
-	<UseMSBuildEngine>False</UseMSBuildEngine>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Distribution|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -59,7 +57,6 @@
     <EnablePackageSigning>False</EnablePackageSigning>
     <IncludeMonoRuntime>False</IncludeMonoRuntime>
     <UseSGen>False</UseSGen>
-	<UseMSBuildEngine>False</UseMSBuildEngine>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
I tried to build Samples/GameStarterKit on MonoMac. But it occured build error.
I fixed build error. It was checked work correctly on master or v1.1.
- Modify references of Lidgren.Network and MonoGame.framework to in submodule
- Replace invalid classes to new one.
