### PR TITLE
- Make sure that input stream is seekable

### DIFF
--- a/cocos2d/platform/PList/PlistDocument.cs
+++ b/cocos2d/platform/PList/PlistDocument.cs
@@ -541,7 +541,14 @@ namespace Cocos2D
 			byte[] buffer = objectTable.GetRange(headerPosition + 1, byteCount).ToArray();
 			Array.Reverse(buffer);
 
-			return new PlistReal(BitConverter.ToSingle(RegulateNullBytes(buffer, 8), 0));
+            if (byteCount > 4)
+            {
+                return new PlistReal((float)BitConverter.ToDouble(RegulateNullBytes(buffer, 8), 0));
+            }
+            else
+            {
+                return new PlistReal(BitConverter.ToSingle(RegulateNullBytes(buffer, 4), 0));
+            }
 		}
 		private PlistString parseBinaryAsciiString(int headerPosition)
 		{


### PR DESCRIPTION
I guess I'm not using a pattern which prevents my current issue but when I'm registering sprite maps with

```
CCSpriteFrameCache.AddSpriteFramesWithFile
```

I get an exception on Android. The plist file is opened via TitleContainer.OpenStream and this returns a non-seekable stream.

```
Microsoft.Xna.Framework.TitleContainer.OpenStream (name="Content/tiles/tiles.plist") in ...cocos2d-xna/MonoGame/MonoGame.Framework/TitleContainer.cs:144
Cocos2D.CCContentManager.InternalLoad<Cocos2D.PlistDocument> (assetName="tiles/tiles.plist", path="tiles/tiles.plist", weakReference=false) in ...cocos2d-xna/cocos2d/Platform/CCContentManager.cs:302
Cocos2D.CCContentManager.Load<Cocos2D.PlistDocument> (assetName="tiles/tiles.plist", weakReference=false) in ...cocos2d-xna/cocos2d/Platform/CCContentManager.cs:230
Cocos2D.CCContentManager.Load<Cocos2D.PlistDocument> (assetName="tiles/tiles.plist") in ...cocos2d-xna/cocos2d/Platform/CCContentManager.cs:185
Cocos2D.CCSpriteFrameCache.AddSpriteFramesWithFile (pszPlist="tiles/tiles.plist") in ...cocos2d-xna/cocos2d/sprite_nodes/CCSpriteFrameCache.cs:192
```

Local vars in PlistDocument looks like this:

```
public void LoadFromXmlFile(Stream data)

this                {Cocos2D.PlistDocument}                                         Cocos2D.PlistDocument
data                {Android.Runtime.InputStreamInvoker}                            Android.Runtime.InputStreamInvoker
base                {System.IO.Stream}                                              System.IO.Stream
BaseInputStream     {android.content.res.AssetManager$AssetInputStream@4142cb70}    Java.IO.InputStreamInvoker
CanRead             true                                                            bool
CanSeek             false                                                           bool
CanWrite            false                                                           bool
Length              System.NotSupportedException: Operation is not supported.       
Position            System.NotSupportedException: Operation is not supported.       
Non-public members                                                                  
magicHeader         (null)                                                          System.Byte[]
```

Simple fix is attached.
