### PR TITLE
Remove zlib reference for Android & iOS, it is redundant

### DIFF
--- a/cocos2d/cocos2d.Android.csproj
+++ b/cocos2d/cocos2d.Android.csproj
@@ -44,9 +44,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <Reference Include="zlib.net">
-      <HintPath>external lib\zlib.net.dll</HintPath>
-    </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>external lib\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>

--- a/cocos2d/cocos2d.iOS.csproj
+++ b/cocos2d/cocos2d.iOS.csproj
@@ -77,9 +77,6 @@
     <Reference Include="ICSharpCode.SharpZipLib">
       <HintPath>external lib\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="zlib.net">
-      <HintPath>external lib\zlib.net.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" Condition="'$(windir)' != '' " />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Remove zlib reference for Android & iOS, it is redundant (code is integrated)
=> not yet updated for other platforms
