### PR TITLE
- Update CCLabelBMFont in visit instead of draw to prevent 'jumping' whe...

### DIFF
--- a/cocos2d/label_nodes/CCLabelBMFont.cs
+++ b/cocos2d/label_nodes/CCLabelBMFont.cs
@@ -946,7 +946,7 @@ namespace Cocos2D
             return pRet;
         }
 
-        public override void Draw()
+        public override void Visit()
         {
             if (m_bLabelDirty)
             {
@@ -954,7 +954,7 @@ namespace Cocos2D
                 m_bLabelDirty = false;
             }
 
-            base.Draw();
+            base.Visit();
         }
     }
 }


### PR DESCRIPTION
Howdi -

I've got a problem with a center aligned CCLabelBMFont when updating the text: The first time it is drawing the updated content its position is not realigned to its new width. Only on the second draw call it will be correct. So the label is basically visually jumping around. 

I moved the update to visit which fixes the problem but I'm not entirely sure if this could have bad side effects ...
