### PR TITLE
Bug fixes for sprite batch

### DIFF
--- a/cocos2d/base_nodes/CCNode.cs
+++ b/cocos2d/base_nodes/CCNode.cs
@@ -1095,7 +1095,7 @@ namespace Cocos2D
         
         #region Child Sorting
 
-        int IComparer<CCNode>.Compare(CCNode n1, CCNode n2)
+        public virtual int Compare(CCNode n1, CCNode n2)
         {
             if (n1.m_nZOrder < n2.m_nZOrder || (n1.m_nZOrder == n2.m_nZOrder && n1.m_uOrderOfArrival < n2.m_uOrderOfArrival))
             {

--- a/cocos2d/sprite_nodes/CCSpriteBatchNode.cs
+++ b/cocos2d/sprite_nodes/CCSpriteBatchNode.cs
@@ -214,6 +214,23 @@ namespace Cocos2D
             m_pobTextureAtlas.RemoveAllQuads();
         }
 
+        public override int Compare(CCNode n1, CCNode n2)
+        {
+            CCSprite s1 = (CCSprite)n1;
+            CCSprite s2 = (CCSprite)n2;
+            if (n1.m_nZOrder < n2.m_nZOrder || (s1.m_nZOrder == s2.m_nZOrder && s1.AtlasIndex < s2.AtlasIndex))
+            {
+                return -1;
+            }
+
+            if (n1 == n2)
+            {
+                return 0;
+            }
+
+            return 1;
+        }
+
         //override sortAllChildren
         public override void SortAllChildren()
         {
@@ -512,7 +529,7 @@ namespace Cocos2D
             }
         }
 
-        public void InsertChild(CCSprite pobSprite, int uIndex)
+        private void InsertChildAt(CCSprite pobSprite, int uIndex)
         {
             pobSprite.BatchNode = this;
             pobSprite.AtlasIndex = uIndex;
@@ -544,7 +561,7 @@ namespace Cocos2D
                 {
                     var pChild = (CCSprite) elements[j];
                     uIndex = AtlasIndexForChild(pChild, pChild.ZOrder);
-                    InsertChild(pChild, uIndex);
+                    InsertChildAt(pChild, uIndex);
                 }
             }
         }


### PR DESCRIPTION
CCSpriteBatchNode would reorder its children but it would sort using the OrderofArrival. This value is reset to zero when nodes are added to sprite batch, therefore causing irregular drawing reordering of its children. The correct sort should use the AtlasIndex instead.
