### PR TITLE
- fix ambiguity caused by MonoTouch.ImageIO.CGImageDestination new AddIm...

### DIFF
--- a/cocos2d/label_nodes/CCLabelUtilities-CoreGraphics.cs
+++ b/cocos2d/label_nodes/CCLabelUtilities-CoreGraphics.cs
@@ -50,7 +50,7 @@ namespace Cocos2D
 			CGImageDestination dest = CGImageDestination.FromUrl (url, typeIdentifier, 1);
 
 			// Add an image to the destination
-			dest.AddImage(bitmap.GetImage(), null);
+            dest.AddImage(bitmap.GetImage(), (NSDictionary)null);
 
 			// Finish the export
 			bool success = dest.Close ();


### PR DESCRIPTION
ios 8.6.4 introduces new methods which break CCLableUtilities
see http://developer.xamarin.com/releases/ios/api_changes/from_8.4.0_to_8.6.0/
