### PR TITLE
- don't use float.Epsilon since it does evaluate to 0 on ARM

### DIFF
--- a/cocos2d/actions/action_camera/CCOrbitCamera.cs
+++ b/cocos2d/actions/action_camera/CCOrbitCamera.cs
@@ -76,7 +76,7 @@ namespace Cocos2D
             r = (float) Math.Sqrt(x * x + y * y + z * z);
             s = (float) Math.Sqrt(x * x + y * y);
             if (s == 0.0f)
-                s = float.Epsilon;
+                s = CCMacros.FLT_EPSILON;
             if (r == 0.0f)
                 r = float.Epsilon;
 

--- a/cocos2d/actions/action_intervals/CCActionInterval.cs
+++ b/cocos2d/actions/action_intervals/CCActionInterval.cs
@@ -58,7 +58,7 @@ namespace Cocos2D
             // by 3% in heavy based action games.
             if (m_fDuration == 0)
             {
-                m_fDuration = float.Epsilon;
+                m_fDuration = CCMacros.FLT_EPSILON;
             }
 
             m_elapsed = 0;
@@ -102,7 +102,7 @@ namespace Cocos2D
 
             Update(Math.Max(0f,
                             Math.Min(1, m_elapsed /
-                                        Math.Max(m_fDuration, float.Epsilon)
+                                Math.Max(m_fDuration, CCMacros.FLT_EPSILON)
                                 )
                        )
                 );

--- a/cocos2d/cocoa/CCGeometry.cs
+++ b/cocos2d/cocoa/CCGeometry.cs
@@ -166,7 +166,7 @@ namespace Cocos2D
         public float Normalize()
         {
             var mag = (float) Math.Sqrt(X * X + Y * Y);
-            if (mag < float.Epsilon)
+            if (mag < CCMacros.FLT_EPSILON)
             {
                 return (0f);
             }
@@ -247,7 +247,7 @@ namespace Cocos2D
             CCPoint b2 = Normalize(b);
             var angle = (float) Math.Atan2(a2.X * b2.Y - a2.Y * b2.X, DotProduct(a2, b2));
 
-            if (Math.Abs(angle) < float.Epsilon)
+            if (Math.Abs(angle) < CCMacros.FLT_EPSILON)
             {
                 return 0.0f;
             }

--- a/cocos2d/predefine/ccMacros.cs
+++ b/cocos2d/predefine/ccMacros.cs
@@ -74,8 +74,9 @@ namespace Cocos2D
             return angle * 57.29577951f; // PI * 180
         }
 
-        [Obsolete("use float.Epsilon instead")]
-        public static readonly float FLT_EPSILON = float.Epsilon; // Was:  1.192092896e-07F;
+        // On Arm float.Epsilon is too small and evalutates to 0
+        // http://msdn.microsoft.com/en-us/library/system.single.epsilon(v=vs.110).aspx
+        public static readonly float FLT_EPSILON = 1.175494351E-38f;
 
         public static float CCContentScaleFactor()
         {


### PR DESCRIPTION
Something the bit me recently: in an ActionInterval I got an Update call with NaN on the device on iOS. In the simulator it was working fine.

The problem is the use of float.Epsilon which is supported on ARM.

see here: http://msdn.microsoft.com/en-us/library/system.single.epsilon(v=vs.110).aspx
and here: https://bugzilla.xamarin.com/show_bug.cgi?id=15802
