### PR TITLE
Fix for FOV setting when any design resolution is larger than 1500 px.

### DIFF
--- a/cocos2d/CCDirector.cs
+++ b/cocos2d/CCDirector.cs
@@ -370,7 +370,7 @@ namespace Cocos2D
                         CCDrawManager.ProjectionMatrix = Matrix.CreatePerspectiveFieldOfView(
                             MathHelper.Pi / 3.0f,
                             size.Width / size.Height,
-                            0.1f, 1500 //ZEye * 2f
+                            0.1f, Math.Max(size.Width,size.Height)*2f // 1500 //ZEye * 2f
                             );
 
                         CCDrawManager.ViewMatrix = Matrix.CreateLookAt(


### PR DESCRIPTION
If you have a design resolution that is larger than 1500 pixels in any dimension then the FOV calculation will not produce a scale factor that fits your target in a smaller screen bounds. The hard coded 1500 Z value becomes a problem, so the solution is to use 2X the maximum dimension of your world.